### PR TITLE
Move proximity gesture code in a dedicated library

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,23 @@
+COPYRIGHT(c) 2017 STMicroelectronics
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  3. Neither the name of STMicroelectronics nor the names of its contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-# Proximity_Gesture
-Gesture library for proximity sensors
+# Proximity Gesture
+
+Arduino library to support gesture-detection using proximity sensors (VL53L0X or VL6180X).
+The APIs provide single swipe gesture detection, directional (left/right) swipe gesture detection and 
+single tap gesture detection.
+
+## Note
+
+You can find examples based on this library in the following packages:
+* VL53L0X: https://github.com/stm32duino/VL53L0X
+* X-NUCLEO-53L0A1: https://github.com/stm32duino/X-NUCLEO-53L0A1
+* X-NUCLEO-6180XA1: https://github.com/stm32duino/X-NUCLEO-6180XA1
+
+## Documentation
+
+You can find the source files at  
+https://github.com/stm32duino/Proximity_Gesture

--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,9 @@
+name=STM32duino Proximity Gesture
+version=1.0.0
+author=AST
+maintainer=stm32duino
+sentence=Allows performing simple gestures detection using proximity sensors
+paragraph=This library provides single swipe gesture detection, directional (left/right) swipe gesture detection and single tap gesture detection.
+category=Device Control
+url=https://github.com/stm32duino/Proximity_Gesture
+architectures=stm32

--- a/src/ring_buffer.cpp
+++ b/src/ring_buffer.cpp
@@ -1,0 +1,184 @@
+/*******************************************************************************
+Copyright © 2015, STMicroelectronics International N.V.
+All rights reserved.
+
+Use and Redistribution are permitted only in accordance with licensing terms 
+available at www.st.com under software reference X-CUBE-6180XA1, and provided
+that the following conditions are met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+* Neither the name of STMicroelectronics nor the
+names of its contributors may be used to endorse or promote products
+derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROTECTED BY STMICROELECTRONICS PATENTS AND COPYRIGHTS.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND
+NON-INFRINGEMENT OF INTELLECTUAL PROPERTY RIGHTS ARE DISCLAIMED.
+IN NO EVENT SHALL STMICROELECTRONICS INTERNATIONAL N.V. BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+********************************************************************************/
+
+/*
+ * $Date: 2015-11-10 11:21:53 +0100 (Tue, 10 Nov 2015) $
+ * $Revision: 2612 $
+ */
+ 
+ 
+#include "ring_buffer.h"
+
+#define ABS(a) ((a>=0) ? (a) : -(a))
+
+int RB_init(ring_buffer_t* rb, int size)
+{
+    rb->buffer_end = rb->buffer + ((size<RB_MAX_SIZE) ? size : RB_MAX_SIZE);
+    rb->size = size;
+    rb->data_start = rb->buffer;
+    rb->data_end = rb->buffer;
+    rb->count = 0;
+    return (size<=RB_MAX_SIZE) ? 0 : -1;
+}
+
+int RB_push(ring_buffer_t* rb, int data)
+{
+    if (rb == NULL || rb->buffer == NULL)
+        return -1;
+
+    *rb->data_end = data;
+    rb->data_end++;
+    if (rb->data_end == rb->buffer_end)
+        rb->data_end = rb->buffer;
+
+    if (RB_full(rb)) {
+        if ((rb->data_start + 1) == rb->buffer_end)
+            rb->data_start = rb->buffer;
+        else
+            rb->data_start++;
+    } else {
+        rb->count++;
+    }
+
+    return 0;
+}
+
+int RB_pop(ring_buffer_t* rb)
+{
+    if (rb == NULL || rb->buffer == NULL)
+        return false;
+
+    int8_t data = *rb->data_start;
+    rb->data_start++;
+    if (rb->data_start == rb->buffer_end)
+        rb->data_start = rb->buffer;
+    rb->count--;
+
+    return data;
+}
+
+bool RB_full(ring_buffer_t* rb)
+{
+    return rb->count == rb->size;
+}
+
+void RB_trace(ring_buffer_t*rb)
+{
+    int i=0;
+    int *ptr;
+    
+    ptr = rb->data_start;
+    //trace_printf("TOF_GESTURES Ring Buffer : ");
+    for(i=0;i<rb->count;i++)
+    {
+        //trace_printf("%d,",*ptr++);
+        if(ptr == rb->buffer_end)
+            ptr = rb->buffer;
+    }
+    //trace_printf("\n");
+}
+
+int RB_sum(ring_buffer_t*rb)
+{
+    int i=0;
+    int sum=0;
+    int *ptr;
+    
+    ptr = rb->data_start;
+    for(i=0;i<rb->count;i++)
+    {
+        sum += *ptr++;
+        if(ptr == rb->buffer_end)
+            ptr = rb->buffer;
+    }
+    return sum;
+}
+
+int RB_mean(ring_buffer_t*rb)
+{
+    return RB_sum(rb)/rb->count;
+}
+
+int RB_mad(ring_buffer_t*rb)
+{
+    int i;
+    int *ptr;
+    int mad=0;
+    int mean;
+    int data;
+    
+    mean = RB_mean(rb);
+       
+    ptr = rb->data_start;
+    for(i=0;i<rb->count;i++)
+    {
+        data = *ptr++;
+        mad += ABS((data - mean));
+        if(ptr == rb->buffer_end)
+            ptr = rb->buffer;
+    }
+    return mad/rb->count;
+}
+
+int RB_dir(ring_buffer_t*rb)
+{
+    int direction = 0;   
+    int i=0;
+    int *ptr;
+    int value1, value2;
+    
+    ptr = rb->data_start;
+    if (rb->count == 0 || rb->count == 1){
+        return 0;
+    } else {
+        value1 = *ptr++; if(ptr == rb->buffer_end) ptr = rb->buffer;
+        value2 = *ptr++; if(ptr == rb->buffer_end) ptr = rb->buffer;
+        direction = ((value2 - value1) > 0) ? 1 : (((value2 -value1) < 0) ? -1 : 0);
+        value1 = value2;
+    }
+    
+    for(i=2;i<rb->count;i++)
+    {
+        value2 = *ptr++; if(ptr == rb->buffer_end) ptr = rb->buffer;
+        if ((direction==1) && ((value2-value1)<0)) {
+            direction = 0;
+            break;
+        }
+        if ((direction==-1) && ((value2-value1)>0)) {
+            direction = 0;
+            break;
+        }
+        if (direction==0) {
+            direction = ((value2 - value1) > 0) ? 1 : (((value2 -value1) < 0) ? -1 : 0);
+        }
+        value1 = value2;
+    }
+    return direction;
+}

--- a/src/ring_buffer.h
+++ b/src/ring_buffer.h
@@ -1,0 +1,144 @@
+/*******************************************************************************
+Copyright © 2015, STMicroelectronics International N.V.
+All rights reserved.
+
+Use and Redistribution are permitted only in accordance with licensing terms 
+available at www.st.com under software reference X-CUBE-6180XA1, and provided
+that the following conditions are met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+* Neither the name of STMicroelectronics nor the
+names of its contributors may be used to endorse or promote products
+derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROTECTED BY STMICROELECTRONICS PATENTS AND COPYRIGHTS.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND
+NON-INFRINGEMENT OF INTELLECTUAL PROPERTY RIGHTS ARE DISCLAIMED.
+IN NO EVENT SHALL STMICROELECTRONICS INTERNATIONAL N.V. BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+********************************************************************************/
+/*
+ * @file ring_buffer.h
+ * $Date: 2015-11-10 11:21:53 +0100 (Tue, 10 Nov 2015) $
+ * $Revision: 2612 $
+ */
+
+#ifndef RING_BUFFER_H_
+#define RING_BUFFER_H_
+
+#include "tof_gestures_platform.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+    
+/** @defgroup misc_ring_buffer Ring Buffer
+ *  @brief    Simple ring buffer implementation
+    @par Description
+    Ring buffer is implemented as a static array of integers of size #RB_MAX_SIZE. The functional size of the ring buffer is
+    programmable. When the ring_buffer is full, new elements added are replacing the older elements. This is typically used
+    to keep an history of the last ranging values measured from the ToF device.
+ *  @ingroup misc
+ *  @{  
+ */
+
+/** Ring Buffer maximum size */
+#define RB_MAX_SIZE 16
+
+/**
+ * @struct ring_buffer
+ * @brief Simple ring buffer of int with a programmable size (max size is #RB_MAX_SIZE)
+ */    
+typedef struct
+{
+    int  buffer[RB_MAX_SIZE];
+    int* buffer_end;            
+    int* data_start;           
+    int* data_end;
+    int count;
+    int size;
+} ring_buffer_t;
+
+/**
+ * @brief Initialize Ring Buffer
+ * @param rb  Ring Buffer pointer
+ * @param size Number of int elements (max size is #RB_MAX_SIZE)
+ * @return 0 on success or -1 if size is greater than #RB_MAX_SIZE
+ */
+int RB_init(ring_buffer_t* rb, int size);
+
+/**
+ * @brief Push one element in Ring Buffer (after the last element)
+ * @par Function Description
+ * If ring buffer is full, added element is replacing the oldest element in the ring buffer
+ * @param rb  Ring Buffer pointer
+ * @param data Element to add
+ * @return 0 on success
+ */
+int RB_push(ring_buffer_t* rb, int data);
+
+/**
+ * @brief pop one element in Ring Buffer (the last element)
+ * @param rb  Ring Buffer pointer
+ * @return element
+ */
+int RB_pop(ring_buffer_t* rb);
+
+/**
+ * @brief Check if ring buffer is full
+ * @param rb  Ring Buffer pointer
+ * @return true if full else false
+ */
+bool RB_full(ring_buffer_t* rb);
+ 
+/**
+ * @brief print/trace all elements in the ring buffer
+ * @param rb  Ring Buffer pointer
+ * @note The TRACE key must be defined in the project
+ */
+void RB_trace(ring_buffer_t*rb);
+
+/**
+ * @brief Return the sum of elements in the ring buffer
+ * @param rb  Ring Buffer pointer
+ * @return The sum
+ */
+int RB_sum(ring_buffer_t*rb);
+
+/**
+ * @brief Return the mean of all elements in the ring buffer
+ * @param rb  Ring Buffer pointer
+ * @return The mean (rounded to integer)
+ */
+int RB_mean(ring_buffer_t*rb);
+
+/**
+ * @brief Return the mean of the absolute differences of each element with the mean
+ * @param rb  Ring Buffer pointer
+ * @return The mad (rounded to integer)
+ */
+int RB_mad(ring_buffer_t*rb);
+
+/**
+ * @brief Return the direction of the curve of points stored in the buffer
+ * @param rb  Ring Buffer pointer
+ * @return 1 if constantly increase, -1 if constantly decrease, 0 otherwise
+ */
+int RB_dir(ring_buffer_t*rb);
+
+ /** @}  */
+
+#ifdef __cplusplus
+}					
+#endif	
+#endif /* RING_BUFFER_H_ */

--- a/src/tof_gestures.h
+++ b/src/tof_gestures.h
@@ -1,0 +1,91 @@
+/*******************************************************************************
+Copyright © 2015, STMicroelectronics International N.V.
+All rights reserved.
+
+Use and Redistribution are permitted only in accordance with licensing terms 
+available at www.st.com under software reference X-CUBE-6180XA1, and provided
+that the following conditions are met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+* Neither the name of STMicroelectronics nor the
+names of its contributors may be used to endorse or promote products
+derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROTECTED BY STMICROELECTRONICS PATENTS AND COPYRIGHTS.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND
+NON-INFRINGEMENT OF INTELLECTUAL PROPERTY RIGHTS ARE DISCLAIMED.
+IN NO EVENT SHALL STMICROELECTRONICS INTERNATIONAL N.V. BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+********************************************************************************/
+
+/*
+ * @file tof_gestures.h
+ * $Date: 2015-11-10 11:21:53 +0100 (Tue, 10 Nov 2015) $
+ * $Revision: 2612 $
+ */
+
+#ifndef TOF_GESTURES_H_
+#define TOF_GESTURES_H_
+
+#include <stdlib.h>
+#include "tof_gestures_platform.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+    
+/** @defgroup tof_gestures 
+ *  @brief    ToF Gesture functions detecting gestures
+ */
+       
+/** @defgroup tof 
+ *  @brief    ToF functions (performing operations on typical ToF data such as range, signalRate
+ */
+
+/** @defgroup misc 
+ *  @brief    Misc functions
+ */    
+
+
+/** Gesture codes
+ */
+enum Gestures_Code_t{
+    GESTURES_NULL                   = 0,    /*!< No gesture detected */
+    GESTURES_SINGLE_TAP             = 1,    /*!< Single tap detected : __TAP__*/
+    GESTURES_SINGLE_SWIPE           = 2,    /*!< Single swipe detected (flat hand) : __WIPE__*/
+    GESTURES_DOUBLE_TAP             = 3,    /*!< Double tap detected : __TAPS__*/
+    GESTURES_DOUBLE_SWIPE           = 4,    /*!< Double swipe detected : __SWIPES__*/
+    GESTURES_HAND_ENTERING          = 5,    /*!< Hand is entering in device field of view : __LC__ */
+    GESTURES_HAND_LEAVING           = 6,    /*!< Hand is leaving from device field of view : __LC__ */
+    GESTURES_LEVEL_CONTROLLED       = 7,    /*!< Hand is controlling a level from the measured distance : __LC__ */
+    GESTURES_SWIPE_LEFT_RIGHT       = 8,    /*!< Directional swipe from left to right : __DIRSWIPE__ */
+    GESTURES_SWIPE_RIGHT_LEFT       = 9,    /*!< Directional swipe from right to left : __DIRSWIPE__ */
+    GESTURES_FLIP_PAGE_LEFT_RIGHT   = 10,    /*!< Page flip from left to right (hand at 45) : __FLIPPAGE__ */
+    GESTURES_FLIP_PAGE_RIGHT_LEFT   = 11,    /*!< Page flip from right to left (hand at 45) : __FLIPPAGE__ */
+    
+    GESTURES_STARTED                = -1,   /*!< A gesture start is detected but full gesture detection is not completed (yet) */
+    GESTURES_DISCARDED              = -2,   /*!< Gesture is discarded */
+    GESTURES_DISCARDED_TOO_SLOW     = -3,   /*!< Gesture is discarded because it is too slow */
+    GESTURES_DISCARDED_TOO_FAST     = -4,   /*!< Gesture is discarded because it is too fast */
+};
+
+#ifndef MIN
+#   define MIN(a,b) (((a)<(b))?(a):(b))
+#endif 
+#ifndef MAX
+#   define MAX(a,b) (((a)>(b))?(a):(b))
+#endif 
+#ifdef __cplusplus
+}					
+#endif	
+#endif /* TOF_GESTURES_H_ */

--- a/src/tof_gestures_DIRSWIPE_1.cpp
+++ b/src/tof_gestures_DIRSWIPE_1.cpp
@@ -1,0 +1,107 @@
+/*******************************************************************************
+Copyright © 2015, STMicroelectronics International N.V.
+All rights reserved.
+
+Use and Redistribution are permitted only in accordance with licensing terms 
+available at www.st.com under software reference X-CUBE-6180XA1, and provided
+that the following conditions are met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+* Neither the name of STMicroelectronics nor the
+names of its contributors may be used to endorse or promote products
+derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROTECTED BY STMICROELECTRONICS PATENTS AND COPYRIGHTS.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND
+NON-INFRINGEMENT OF INTELLECTUAL PROPERTY RIGHTS ARE DISCLAIMED.
+IN NO EVENT SHALL STMICROELECTRONICS INTERNATIONAL N.V. BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+********************************************************************************/
+
+/*
+ * $Date: 2015-11-10 11:21:53 +0100 (Tue, 10 Nov 2015) $
+ * $Revision: 2612 $
+ */
+
+#include "tof_gestures.h"
+#include "tof_gestures_DIRSWIPE_1.h"
+
+int tof_gestures_initDIRSWIPE_1(int32_t rangeThreshold_mm, long minSwipeDuration, long maxSwipeDuration, Gesture_DIRSWIPE_1_Data_t *data){
+    int status=0;
+    // Init left and right motion
+    status |= tof_initMotion(rangeThreshold_mm, &(data->motionDetectorLeft));
+    status |= tof_initMotion(rangeThreshold_mm, &(data->motionDetectorRight));
+    data->minSwipeDuration = minSwipeDuration;
+    data->maxSwipeDuration = maxSwipeDuration;
+    data->state = GESTURES_DIRSWIPE_START;
+    data->timestamp = 0;
+    data->gesture_start_from_right = -1;
+    return status;
+}
+
+int tof_gestures_detectDIRSWIPE_1(int32_t left_range_mm, int32_t right_range_mm, Gesture_DIRSWIPE_1_Data_t *data){
+    int return_code = GESTURES_NULL;
+    int r_motion_code, l_motion_code;
+    unsigned long timestamp = GET_TIME_STAMP();
+    long duration=0;
+    
+    // Get left and right motion
+    l_motion_code = tof_getMotion(left_range_mm, &(data->motionDetectorLeft));
+    r_motion_code = tof_getMotion(right_range_mm, &(data->motionDetectorRight));
+    
+    //TOF_GESTURES_DEBUG(DIRSWIPE_1,"lmotion=%d, rmotion=%d", l_motion_code, r_motion_code);
+    
+    switch(data->state){
+        case GESTURES_DIRSWIPE_START:
+            if(l_motion_code == GESTURES_MOTION_DOWN_STATE && r_motion_code == GESTURES_MOTION_RAISE_UP){
+                if(data->motionDetectorRight.duration > data->minSwipeDuration){
+                    data->gesture_start_from_right = 1;
+                    data->state = GESTURES_DIRSWIPE_END;
+                    data->timestamp = timestamp;
+                    //TOF_GESTURES_DEBUG(DIRSWIPE_1,"Start right to left (%d ms)",data->motionDetectorRight.duration);
+                }else{
+                    return_code = GESTURES_DISCARDED_TOO_FAST;
+                }
+            }else if(r_motion_code == GESTURES_MOTION_DOWN_STATE && l_motion_code == GESTURES_MOTION_RAISE_UP){
+                if(data->motionDetectorRight.duration > data->minSwipeDuration){
+                    data->gesture_start_from_right = 0;
+                    data->state = GESTURES_DIRSWIPE_END;
+                    data->timestamp = timestamp;
+                    //TOF_GESTURES_DEBUG(DIRSWIPE_1,"Start left to right(%d ms)",data->motionDetectorRight.duration);
+                }else{
+                    return_code = GESTURES_DISCARDED_TOO_FAST;
+                }
+            }   
+            break;
+        case GESTURES_DIRSWIPE_END:
+            duration = timestamp - data->timestamp;
+            if(duration > data->maxSwipeDuration){
+                // Gesture is too long : discard it
+                data->state = GESTURES_DIRSWIPE_START;
+                data->gesture_start_from_right = -1;
+                //TOF_GESTURES_DEBUG(DIRSWIPE_1,"Too slow");
+                return_code = GESTURES_DISCARDED_TOO_SLOW;
+            }else if ((data->gesture_start_from_right == 1 && l_motion_code == GESTURES_MOTION_RAISE_UP && r_motion_code == GESTURES_MOTION_UP_STATE) || (data->gesture_start_from_right == 0 && r_motion_code == GESTURES_MOTION_RAISE_UP && l_motion_code == GESTURES_MOTION_UP_STATE)){
+                // Gesture detected
+                data->state = GESTURES_DIRSWIPE_START;
+                return_code = (data->gesture_start_from_right) ? GESTURES_SWIPE_RIGHT_LEFT : GESTURES_SWIPE_LEFT_RIGHT;
+                //TOF_GESTURES_DEBUG(DIRSWIPE_1,"DETECTED");
+            }else{
+                // Waiting...
+                //TOF_GESTURES_DEBUG(DIRSWIPE_1,"Waiting...");
+                return_code = GESTURES_STARTED;
+            }             
+            break;
+    }
+    return return_code;
+}

--- a/src/tof_gestures_DIRSWIPE_1.h
+++ b/src/tof_gestures_DIRSWIPE_1.h
@@ -1,0 +1,99 @@
+/*******************************************************************************
+Copyright © 2015, STMicroelectronics International N.V.
+All rights reserved.
+
+Use and Redistribution are permitted only in accordance with licensing terms 
+available at www.st.com under software reference X-CUBE-6180XA1, and provided
+that the following conditions are met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+* Neither the name of STMicroelectronics nor the
+names of its contributors may be used to endorse or promote products
+derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROTECTED BY STMICROELECTRONICS PATENTS AND COPYRIGHTS.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND
+NON-INFRINGEMENT OF INTELLECTUAL PROPERTY RIGHTS ARE DISCLAIMED.
+IN NO EVENT SHALL STMICROELECTRONICS INTERNATIONAL N.V. BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+********************************************************************************/
+
+/*
+ * @file tof_gestures_DIRSWIPE_1.h
+ * $Date: 2015-11-10 11:21:53 +0100 (Tue, 10 Nov 2015) $
+ * $Revision: 2612 $
+ */
+
+#ifndef TOF_GESTURES_DIRSWIPE_1_H_
+#define TOF_GESTURES_DIRSWIPE_1_H_
+
+#include "tof_gestures_platform.h"
+#include "tof_motion.h"
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @defgroup tof_gestures_DIRSWIPE_1 Directional SWIPE (1)
+ *  @brief    Directional (left/right) Swipe gesture detection based on motion detector (dual ToF devices)
+    @par Description
+    This tof_gestures module allows to detect a directional swipe (from left to right or from right to left) using
+    two ToF devices (left and right). It is based on the tof_motion module with simple threshold and timing considerations.
+    It returns one of the following gestures codes : ::GESTURES_SWIPE_LEFT_RIGHT, ::GESTURES_SWIPE_RIGHT_LEFT when gesture is detected
+    or ::GESTURES_NULL, ::GESTURES_DISCARDED_TOO_SLOW or ::GESTURES_DISCARDED_TOO_FAST when no gesture is detected.
+    @par Known Limitations
+    None (very fast swipes can be detected)
+ *  @ingroup tof_gestures
+ *  @{  
+ */
+
+    
+/** Codes used to detect directional swipes (internal state machine)
+ */
+enum Gestures_DirSwipe_Code_t{
+    GESTURES_DIRSWIPE_START   = 0, /*!< Ready to detect gesture start */
+    GESTURES_DIRSWIPE_END     = 1, /*!< Ready to detect gesture end */
+};
+    
+/**
+ * @struct Gesture_DIRSWIPE_1_Data_t
+ * @brief Data structure for directional swipes detection (using two ranging devices)
+ */ 
+typedef struct {
+    long minSwipeDuration;                     /*!< Input : Minimum duration of a swipe to be detected */  
+    long maxSwipeDuration;                     /*!< Input : Maximum duration of a swipe to be detected */
+    MotionData_t motionDetectorLeft;          /*!< Private : Motion detector associated to the left ranging device */
+    MotionData_t motionDetectorRight;         /*!< Private : Motion detector associated to the right ranging device */
+    int state;                                /*!< Private : Internal state machine */  
+    int gesture_start_from_right;             /*!< Private : Obvious */   
+    unsigned long timestamp;                  /*!< Private : Obvious */
+} Gesture_DIRSWIPE_1_Data_t;
+
+/**
+ * @brief Initialize gesture data
+ * @return 0 on success
+ */
+int tof_gestures_initDIRSWIPE_1(int32_t threshold, long minSipeDuration, long maxSwipeDuration, Gesture_DIRSWIPE_1_Data_t *data);
+/**
+ * @brief Detect gesture
+ * @return One of these gestures code from ::Gestures_Code_t : ::GESTURES_SWIPE_LEFT_RIGHT, ::GESTURES_SWIPE_RIGHT_LEFT, ::GESTURES_NULL, ::GESTURES_DISCARDED_TOO_SLOW or ::GESTURES_DISCARDED_TOO_FAST  
+ */
+int tof_gestures_detectDIRSWIPE_1(int32_t left_range_mm, int32_t right_range_mm, Gesture_DIRSWIPE_1_Data_t *data); 
+
+ /** @}  */
+
+#ifdef __cplusplus
+}					
+#endif	
+#endif /* TOF_GESTURES_DIRSWIPE_1_H_ */

--- a/src/tof_gestures_SWIPE_1.cpp
+++ b/src/tof_gestures_SWIPE_1.cpp
@@ -1,0 +1,126 @@
+/*******************************************************************************
+Copyright © 2015, STMicroelectronics International N.V.
+All rights reserved.
+
+Use and Redistribution are permitted only in accordance with licensing terms 
+available at www.st.com under software reference X-CUBE-6180XA1, and provided
+that the following conditions are met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+* Neither the name of STMicroelectronics nor the
+names of its contributors may be used to endorse or promote products
+derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROTECTED BY STMICROELECTRONICS PATENTS AND COPYRIGHTS.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND
+NON-INFRINGEMENT OF INTELLECTUAL PROPERTY RIGHTS ARE DISCLAIMED.
+IN NO EVENT SHALL STMICROELECTRONICS INTERNATIONAL N.V. BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+********************************************************************************/
+
+/*
+ * $Date$
+ * $Revision$
+ */
+
+#include "tof_gestures.h"
+#include "tof_gestures_SWIPE_1.h"
+
+int tof_gestures_initSWIPE_1(Gesture_SWIPE_1_Data_t *data){
+    int status=0;
+    status |= (int)(RB_init(&(data->rangeList),SWIPE_1_BUFFER_SIZE));
+    data->meanBackground = 0;
+    data->meanHand = 0;
+    data->gestureCode = GESTURES_NULL;
+    data->cpt = SWIPE_1_SENSITIVITY;
+    return status;
+}
+
+int tof_gestures_detectSWIPE_1(int32_t range_mm, Gesture_SWIPE_1_Data_t *data){
+    int time = GET_TIME_STAMP();
+
+    /* Default state */
+    if (data->gestureCode == GESTURES_NULL){
+    	// Calculate background distance (averaging)
+    	data->meanBackground = (data->rangeList.count==0) ? 0 : RB_mean(&(data->rangeList));
+    	// Check current distance vs background distance
+    	if (range_mm < (((100-SWIPE_1_BACKGROUND_VARIATION) * data->meanBackground) / 100)){
+    		// big variation detected => hand entering in FoV
+    		if (data->cpt == 0) {
+    			// Potential spikes (duster ?) skipped
+    			data->cpt = SWIPE_1_SENSITIVITY;
+				data->gestureCode = GESTURES_HAND_ENTERING;
+				RB_init(&(data->rangeList),SWIPE_1_BUFFER_SIZE);
+				RB_push(&(data->rangeList), range_mm);
+				data->timestamp = time;
+				//TOF_GESTURES_DEBUG(SWIPE_1,"(background=%d, current=%d) => HAND_ENTERING", data->meanBackground, range_mm);
+    		} else {
+    			data->cpt--;
+    			//TOF_GESTURES_DEBUG(SWIPE_1,"(background=%d, current=%d) => SKIP", data->meanBackground, range_mm);
+    		}
+    	}else{
+    		// no variation => keep averaging background
+    		RB_push(&(data->rangeList), range_mm);
+    	}
+
+    /* Hand entering */
+    } else if (data->gestureCode == GESTURES_HAND_ENTERING){
+    	// Calculate hand distance (averaging)
+    	data->meanHand = (data->rangeList.count==0) ? 0 : RB_mean(&(data->rangeList));
+    	// Check current distance vs hand mean distance
+    	if ((range_mm < ((data->meanHand * (100-SWIPE_1_HAND_VARIATION)) / 100)) || ((((data->meanHand * (100+SWIPE_1_HAND_VARIATION)) / 100) < range_mm))){
+    		// Big variation => Hand leaving
+			data->gestureCode = GESTURES_HAND_LEAVING;
+			RB_init(&(data->rangeList),SWIPE_1_BUFFER_SIZE);
+			RB_push(&(data->rangeList), range_mm);
+			data->timestamp = time;
+			//TOF_GESTURES_DEBUG(SWIPE_1,"(meanHand=%d, current=%d) => HAND_LEAVING", data->meanHand, range_mm);
+    	} else if ((time - data->timestamp) > SWIPE_1_MAX_SWIPE_DURATION) {
+    		// Too slow => discard (swipe is too slow, this may be a background change for a long time)
+			data->gestureCode = GESTURES_DISCARDED_TOO_SLOW;
+			RB_init(&(data->rangeList),SWIPE_1_BUFFER_SIZE);
+			//TOF_GESTURES_DEBUG(SWIPE_1,"DISCARDED_TOO_SLOW");
+    	} else {
+    		// No big variation => remains in this state
+			RB_push(&(data->rangeList), range_mm);
+			//TOF_GESTURES_DEBUG(SWIPE_1, "Wait (meanHand=%d, current=%d)", data->meanHand, range_mm);
+    	}
+
+    /* Hand leaving */
+    } else if (data->gestureCode == GESTURES_HAND_LEAVING){
+    	// Check current distance vs background distance (previously calculated)
+    	if ((((data->meanBackground * (100-SWIPE_1_BACKGROUND_VARIATION)) / 100) < range_mm) && (range_mm < (((data->meanBackground * (100+SWIPE_1_BACKGROUND_VARIATION)) / 100)))){
+    		// Almost same => Swipe detected/finished
+    		data->gestureCode = GESTURES_SINGLE_SWIPE;
+    		//data->cpt = 0;
+    		RB_init(&(data->rangeList),SWIPE_1_BUFFER_SIZE);
+    		//return_code = GESTURES_SINGLE_SWIPE;
+    		//TOF_GESTURES_DEBUG(SWIPE_1, "(background=%d, current==%d) => SINGLE_SWIPE\n", data->meanBackground, range_mm);
+    		//uart_printf("2 : Next state : %d, (background=%d), range=%d (SWIPE)\n", data->gestureCode, data->meanBackground, range_mm);
+    	} else if ((time - data->timestamp) > SWIPE_1_BACKGROUND_TIMEOUT){
+    		// To slow to converge back to background distance => discard (background may have change during the gesture)
+    		data->gestureCode = GESTURES_DISCARDED;
+			RB_init(&(data->rangeList),SWIPE_1_BUFFER_SIZE);
+			//TOF_GESTURES_DEBUG(SWIPE_1,"DISCARDED");
+    	} else {
+    		// Wait for convergence towards background
+    		//TOF_GESTURES_DEBUG(SWIPE_1,"Wait (background=%d, current=%d)", data->meanBackground, range_mm);
+    	}
+
+    /* Swipe detected or discarded */
+    } else {
+    	data->gestureCode = GESTURES_NULL;
+    }
+
+    return data->gestureCode;
+}

--- a/src/tof_gestures_SWIPE_1.h
+++ b/src/tof_gestures_SWIPE_1.h
@@ -1,0 +1,113 @@
+/*******************************************************************************
+Copyright © 2015, STMicroelectronics International N.V.
+All rights reserved.
+
+Use and Redistribution are permitted only in accordance with licensing terms 
+available at www.st.com under software reference X-CUBE-6180XA1, and provided
+that the following conditions are met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+* Neither the name of STMicroelectronics nor the
+names of its contributors may be used to endorse or promote products
+derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROTECTED BY STMICROELECTRONICS PATENTS AND COPYRIGHTS.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND
+NON-INFRINGEMENT OF INTELLECTUAL PROPERTY RIGHTS ARE DISCLAIMED.
+IN NO EVENT SHALL STMICROELECTRONICS INTERNATIONAL N.V. BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+********************************************************************************/
+
+/*
+ * @file tof_gestures_SWIPE_1.h
+ * $Date$
+ * $Revision$
+ */
+
+#ifndef TOF_GESTURES_SWIPE_1_H_
+#define TOF_GESTURES_SWIPE_1_H_
+
+#include "tof_gestures_platform.h"
+#include "ring_buffer.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+ 
+/** @defgroup tof_gestures_SWIPE_1 Single SWIPE (1)
+ *  @brief    Single Swipe gesture detection based on dynamic thresholds applied on range (single ToF device)
+    @par Description
+    This tof_gestures module allows to detect in a very robust way a single SWIPE (hand, finger, object) with a single ToF device. Returned
+    gestures code are one of the following ones : ::GESTURES_HAND_ENTERING, ::GESTURES_HAND_LEAVING, ::GESTURES_SINGLE_SWIPE during swipe
+    detection or ::GESTURES_NULL, ::GESTURES_DISCARDED, ::GESTURES_DISCARDED_TOO_SLOW in case SWIPE is not detected or discarded.
+    @par Algorithm Description
+    The approach consists in collecting __range__ samples over the time to get the background distance when no object is crossing the
+    device FoV. A variation of the returned distance versus the background is detected as a hand/object entering in the FoV. A simple
+    state machine is used to detect when the object will go out from the FoV. This module allows to detect any kind of swipes at all speeds
+    (very low, medium and very fast) and with any tilts of the hand.
+    @par Algorithm tuning
+    A set of macros are defined in the module header file to tune the swipe detection.
+    @par Known Limitations
+    @li A gesture with hand leaving the FoV from the top direction (instead of left/right) may be detected as Swipe
+    @li A Swipe may be wrongly detected when an object is placed at the border of the device FoV (this can be corected with some hysteresis filters)
+ *  @ingroup tof_gestures
+ *  @{  
+ */
+
+/** Buffer size used for averaging purpose */
+#define SWIPE_1_BUFFER_SIZE 16
+/** Background distance accepted variation (20%) */
+#define SWIPE_1_BACKGROUND_VARIATION 20
+/** Hand distance accepted variation (40%) */
+#define SWIPE_1_HAND_VARIATION 40
+/** State machine will reset if hand remains more than x msec in the FoV */
+#define SWIPE_1_MAX_SWIPE_DURATION 1000
+/** Max duration for distance to converge back to background when hand has left FoV */
+#define SWIPE_1_BACKGROUND_TIMEOUT 100
+/** Number of ranging distances to skip before starting gesture detection (0:max sensitivity) */
+#define SWIPE_1_SENSITIVITY 	   0
+
+
+/**
+ * @struct Gesture_SWIPE_1_Data_t
+ * @brief Data structure for single swipe gesture detection
+ */
+typedef struct {
+	int gestureCode;                /*!< Output : Gesture intermediate code */
+	ring_buffer_t rangeList;          /*!< Private : List of range samples */
+    int meanBackground;				/*!< Private : Mean distance of the background */
+    int meanHand;					/*!< Private : Mean distance of the detected hand/object */
+    int timestamp;					/*!< Private : Used for internal timing */
+    int cpt;						/*!< Private : Internal counter */
+} Gesture_SWIPE_1_Data_t;    
+
+/**
+ * @brief Initialize gesture data
+ * @return 0 on success
+ */
+int tof_gestures_initSWIPE_1(Gesture_SWIPE_1_Data_t *data);
+/**
+ * @brief Detect gesture
+ * @return One of these gestures code from ::Gestures_Code_t : ::GESTURES_HAND_ENTERING, ::GESTURES_HAND_LEAVING, ::GESTURES_SINGLE_SWIPE or
+ * ::GESTURES_NULL, ::GESTURES_DISCARDED, ::GESTURES_DISCARDED_TOO_SLOW
+ * @warning This function must be called all the time, even if no valid range_mm is available from the ToF device.
+ * In that case, call the function with the typical max ranging capability of the device
+ *
+ */
+int tof_gestures_detectSWIPE_1(int32_t range_mm, Gesture_SWIPE_1_Data_t *data); 
+
+ /** @}  */
+#ifdef __cplusplus
+}					
+#endif	
+#endif /* TOF_GESTURES_SWIPE_1_H_ */

--- a/src/tof_gestures_TAP_1.cpp
+++ b/src/tof_gestures_TAP_1.cpp
@@ -1,0 +1,119 @@
+/*******************************************************************************
+Copyright © 2015, STMicroelectronics International N.V.
+All rights reserved.
+
+Use and Redistribution are permitted only in accordance with licensing terms 
+available at www.st.com under software reference X-CUBE-6180XA1, and provided
+that the following conditions are met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+* Neither the name of STMicroelectronics nor the
+names of its contributors may be used to endorse or promote products
+derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROTECTED BY STMICROELECTRONICS PATENTS AND COPYRIGHTS.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND
+NON-INFRINGEMENT OF INTELLECTUAL PROPERTY RIGHTS ARE DISCLAIMED.
+IN NO EVENT SHALL STMICROELECTRONICS INTERNATIONAL N.V. BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+********************************************************************************/
+
+/*
+ * $Date$
+ * $Revision$
+ */
+
+#include "tof_gestures.h"
+#include "tof_gestures_TAP_1.h"
+
+int tof_gestures_initTAP_1(Gesture_TAP_1_Data_t *data){
+    int status=0;
+    status |= (int)(RB_init(&(data->rangeList),TAP_1_BUFFER_SIZE));
+    data->timestampLastDetectedTap = 0;
+    data->nbOfDataToDecide = TAP_1_NB_OF_DATA_TO_DECIDE;
+    data->meanBackground = 0;
+    data->gestureCode = GESTURES_NULL;
+    data->timestamp = 0;
+    return status;
+}
+
+int tof_gestures_detectTAP_1(int32_t range_mm, Gesture_TAP_1_Data_t *data){
+    int time = GET_TIME_STAMP();
+    int madRange = 0;
+    int dir;
+    int delta_time = 0;
+    int background_threshold = 0;
+
+    // Default state
+	if (data->gestureCode == GESTURES_NULL){
+		// Calculate background distance (averaging)
+		data->meanBackground = (data->rangeList.count==0) ? 0 : RB_mean(&(data->rangeList));
+		background_threshold = (((100-TAP_1_BACKGROUND_VARIATION) * data->meanBackground) / 100);
+		// Check current distance vs background distance
+		if (range_mm < background_threshold){
+			// big variation detected => hand entering in FoV
+			data->gestureCode = GESTURES_HAND_ENTERING;
+			RB_init(&(data->rangeList),TAP_1_BUFFER_SIZE);
+			RB_push(&(data->rangeList), range_mm);
+			data->timestamp = time;
+			//TOF_GESTURES_DEBUG(TAP_1,"(background_thd=%d, current=%d, hand_entering=1)", background_threshold, range_mm);
+		}else{
+    		// no variation => keep averaging background
+			RB_push(&(data->rangeList), range_mm);
+    		//TOF_GESTURES_DEBUG(TAP_1,"(background_thd=%d, current=%d, hand_entering=0)", background_threshold, range_mm);
+    	}
+
+
+	// Hand entering
+	} else if (data->gestureCode == GESTURES_HAND_ENTERING){
+		// Push the range value in the buffer
+		RB_push(&(data->rangeList), range_mm);
+
+		// Try to detect a Tap gesture as soon as possible (4 data are enough for normal/fast gestures speed)
+		if(data->rangeList.count == data->nbOfDataToDecide){
+			// Calculate MAD
+			madRange = RB_mad(&(data->rangeList));
+			dir = RB_dir(&(data->rangeList));
+			delta_time = time - data->timestampLastDetectedTap;
+			// Try to detect a TAP
+			//  MAD is higher than a threshold, ranging elements stored in the buffer are decreasing and last TAP has been
+			//  detected more than 250 ms ago (too avoid 2 TAPS being reported in case of a slow tap)
+			if((madRange > 12) && (dir<0) && (delta_time>250)){
+				// Big negative range variation => TAP
+				data->timestampLastDetectedTap = time;
+				RB_trace(&(data->rangeList));
+				RB_init(&(data->rangeList),16);
+				data->gestureCode = GESTURES_SINGLE_TAP;
+				//TOF_GESTURES_DEBUG(TAP_1,"(madRange=%d, delta_time=%d, dir=%d) => TAP", madRange, delta_time, dir);
+
+			}else{
+				// No TAP detected
+				RB_init(&(data->rangeList),16);
+				data->gestureCode = GESTURES_NULL;
+				//TOF_GESTURES_DEBUG(TAP_1,"(madRange=%d, delta_time=%d, dir=%d) => no TAP", madRange, delta_time, dir);
+			}
+
+			//TOF_GESTURES_DEBUG(TAP_1,"(hand_entering=1, current=%d, decide=1, madRange=%d, dir=%d, tap=%d)", range_mm, madRange, dir, (int)(data->gestureCode == GESTURES_SINGLE_TAP));
+
+		}
+		//TOF_GESTURES_DEBUG(TAP_1,"(hand_entering=1, current=%d, decide=0, tap=0)", range_mm, (int)(data->rangeList.count == data->nbOfDataToDecide));
+
+	// Tap detected
+	} else {
+		// Reset gesture code state machine
+		data->gestureCode = GESTURES_NULL;
+	}
+
+	 return data->gestureCode;
+}
+

--- a/src/tof_gestures_TAP_1.h
+++ b/src/tof_gestures_TAP_1.h
@@ -1,0 +1,100 @@
+/*******************************************************************************
+Copyright © 2015, STMicroelectronics International N.V.
+All rights reserved.
+
+Use and Redistribution are permitted only in accordance with licensing terms 
+available at www.st.com under software reference X-CUBE-6180XA1, and provided
+that the following conditions are met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+* Neither the name of STMicroelectronics nor the
+names of its contributors may be used to endorse or promote products
+derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROTECTED BY STMICROELECTRONICS PATENTS AND COPYRIGHTS.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND
+NON-INFRINGEMENT OF INTELLECTUAL PROPERTY RIGHTS ARE DISCLAIMED.
+IN NO EVENT SHALL STMICROELECTRONICS INTERNATIONAL N.V. BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+********************************************************************************/
+
+/*
+ * @file tof_gestures_TAP_1.h
+ * $Date$
+ * $Revision$
+ */
+
+#ifndef TOF_GESTURES_TAP_1_H_
+#define TOF_GESTURES_TAP_1_H_
+
+#include "tof_gestures_platform.h"
+#include "ring_buffer.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+ 
+/** @defgroup tof_gestures_TAP_1 Single TAP (1)
+ *  @brief    Single Tap gesture detection based on simple analysis (MAD) of range (single ToF device)
+    @par Description
+    This tof_gestures module allows to detect in a very robust way a single TAP (flat hand going down) with a single ToF device. Returned
+    gestures code are one of the following ones : ::GESTURES_SINGLE_TAP or ::GESTURES_NULL in case no TAP is detected.
+    @par Algorithm Description
+    The approach consists in collecting __range__ samples when a target (hand) is detected by the ranging device. Then, MAD
+    (Mean of Aboslute Difference versus the mean) is calculated and TAP gesture is detected based on a threshold.
+ *  @ingroup tof_gestures
+ *  @{  
+ */
+
+
+
+/** Mean variation to start tap detection (5%) */
+#define TAP_1_BACKGROUND_VARIATION 5
+/** Buffer size used for background mean calculation */
+#define TAP_1_BUFFER_SIZE 16
+/** Minimum number of ranging data to get before deciding to detect a TAP */
+#define TAP_1_NB_OF_DATA_TO_DECIDE 4
+
+/**
+ * @struct Gesture_TAP_1_Data_t
+ * @brief Data structure for single tap gesture detection
+ */
+typedef struct {
+	int gestureCode;                /*!< Output : Gesture intermediate code */
+    ring_buffer_t rangeList;  		/*!< Private : List of range samples */
+    int timestampLastDetectedTap;	/*!< Private : Time of the last detected TAP */
+    int nbOfDataToDecide;   		/*!< Private : Number of range data collected to detect a TAP in a very robust way */
+    int meanBackground;				/*!< Private : Mean distance of the background */
+    int timestamp;					/*!< Private : Used for internal timing */
+} Gesture_TAP_1_Data_t;    
+
+/**
+ * @brief Initialize gesture data
+ * @return 0 on success
+ */
+int tof_gestures_initTAP_1(Gesture_TAP_1_Data_t *data);
+
+
+/**
+ * @brief Detect gesture
+ * @return One of these gestures code from ::Gestures_Code_t : ::GESTURES_SINGLE_TAP or ::GESTURES_NULL
+ * @warning This function must be called all the time, even if no valid range_mm is available from the ToF device.
+ * In that case, call the function with the typical max ranging capability of the device
+ */
+int tof_gestures_detectTAP_1(int32_t range_mm, Gesture_TAP_1_Data_t *data);
+
+ /** @}  */
+#ifdef __cplusplus
+}					
+#endif	
+#endif /* TOF_GESTURES_TAP_1_H_ */

--- a/src/tof_gestures_platform.h
+++ b/src/tof_gestures_platform.h
@@ -1,0 +1,68 @@
+/*******************************************************************************
+Copyright © 2015, STMicroelectronics International N.V.
+All rights reserved.
+
+Use and Redistribution are permitted only in accordance with licensing terms 
+available at www.st.com under software reference X-CUBE-6180XA1, and provided
+that the following conditions are met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+* Neither the name of STMicroelectronics nor the
+names of its contributors may be used to endorse or promote products
+derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROTECTED BY STMICROELECTRONICS PATENTS AND COPYRIGHTS.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND
+NON-INFRINGEMENT OF INTELLECTUAL PROPERTY RIGHTS ARE DISCLAIMED.
+IN NO EVENT SHALL STMICROELECTRONICS INTERNATIONAL N.V. BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+********************************************************************************/
+
+/*
+ * @file tof_gestures_platform.h
+ * $Date: 2015-11-10 11:21:53 +0100 (Tue, 10 Nov 2015) $
+ * $Revision: 2612 $
+ */
+
+#ifndef TOF_GESTURES_PLATFORM_H_
+#define TOF_GESTURES_PLATFORM_H_
+
+#include <Arduino.h>
+#include "tof_gestures_types.h"
+
+/**
+ * @def GET_TIME_STAMP
+ * @brief Return a timestamp in ms (platform-dependent)
+ */
+#define GET_TIME_STAMP()  millis()
+
+#define ROMABLE_DATA
+typedef float float_t;
+
+
+enum gestures_modules_mask{
+    NONE            = 0x0000,
+    LC_1            = 0x0001,
+    TAP_SWIPE_1     = 0x0002,
+    DIRSWIPE_1      = 0x0004,
+    MOTION          = 0x0010,
+    COVERAGE        = 0x0020,
+    LC_TAP_SWIPE_1  = 0x0040,
+    TAP_SWIPE_2     = 0x0100,
+};
+
+
+//#define TOF_GESTURES_DEBUG(fmt, ... ) (void)0
+//#define TOF_GESTURES_DEBUG_SET_MODULES(modulesMask) (void)0
+	
+#endif /* TOF_GESTURES_PLATFORM_H_ */

--- a/src/tof_gestures_types.h
+++ b/src/tof_gestures_types.h
@@ -1,0 +1,49 @@
+/*******************************************************************************
+Copyright © 2015, STMicroelectronics International N.V.
+All rights reserved.
+
+Use and Redistribution are permitted only in accordance with licensing terms 
+available at www.st.com under software reference X-CUBE-6180XA1, and provided
+that the following conditions are met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+* Neither the name of STMicroelectronics nor the
+names of its contributors may be used to endorse or promote products
+derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROTECTED BY STMICROELECTRONICS PATENTS AND COPYRIGHTS.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND
+NON-INFRINGEMENT OF INTELLECTUAL PROPERTY RIGHTS ARE DISCLAIMED.
+IN NO EVENT SHALL STMICROELECTRONICS INTERNATIONAL N.V. BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+********************************************************************************/
+
+/*
+ * @file tof_gestures_types.h
+ * $Date: 2015-11-10 11:21:53 +0100 (Tue, 10 Nov 2015) $
+ * $Revision: 2612 $
+ */
+ 
+#ifndef TOF_GESTURES_TYPES_H_
+#define TOF_GESTURES_TYPES_H_
+
+
+#include <stdint.h>
+#include <stddef.h> /* these is for NULL */
+#include <stdbool.h>
+
+#ifndef NULL
+#error "review  NULL definition or add required include "
+#endif
+
+#endif /* TOF_GESTURES_TYPES_H_ */

--- a/src/tof_motion.cpp
+++ b/src/tof_motion.cpp
@@ -1,0 +1,85 @@
+/*******************************************************************************
+Copyright © 2015, STMicroelectronics International N.V.
+All rights reserved.
+
+Use and Redistribution are permitted only in accordance with licensing terms 
+available at www.st.com under software reference X-CUBE-6180XA1, and provided
+that the following conditions are met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+* Neither the name of STMicroelectronics nor the
+names of its contributors may be used to endorse or promote products
+derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROTECTED BY STMICROELECTRONICS PATENTS AND COPYRIGHTS.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND
+NON-INFRINGEMENT OF INTELLECTUAL PROPERTY RIGHTS ARE DISCLAIMED.
+IN NO EVENT SHALL STMICROELECTRONICS INTERNATIONAL N.V. BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+********************************************************************************/
+
+/*
+ * $Date: 2015-11-10 11:21:53 +0100 (Tue, 10 Nov 2015) $
+ * $Revision: 2612 $
+ */
+
+#include "tof_motion.h"
+
+int tof_initMotion(int threshold, MotionData_t *data){
+    data->threshold = threshold;
+    data->firstTime = true;
+    data->duration = 0;
+    data->previousRange = 0;
+    data->timestamp = 0;
+    return 0;
+}
+    
+    
+int tof_getMotion(int32_t range_mm, MotionData_t *data){
+    int return_code;
+    unsigned long timestamp = GET_TIME_STAMP();
+    bool belowThreshold, isContinuousMotion;
+    
+    if(data->firstTime)
+    {
+        data->firstTime = false;
+        data->timestamp = timestamp;
+        data->previousRange = range_mm;
+        belowThreshold = (range_mm < data->threshold);
+        isContinuousMotion = true;
+        return_code = ( belowThreshold ) ? GESTURES_MOTION_DOWN_STATE : GESTURES_MOTION_UP_STATE;
+        data->duration = 1;
+        return return_code;
+    }
+    
+    data->duration = 0;
+	return_code = GESTURES_MOTION_NULL;
+	belowThreshold  = (range_mm < data->threshold);
+	isContinuousMotion  = ( belowThreshold ==  (data->previousRange < data->threshold));
+	data->previousRange = range_mm;
+    
+    //TOF_GESTURES_DEBUG(MOTION,"range=%d, belowThreshold=%d, isContinuousMotion=%d", range_mm, belowThreshold,isContinuousMotion);
+
+	// update
+	data->duration = (long)(timestamp - data->timestamp);
+	if(isContinuousMotion)
+	{
+		return_code = ( belowThreshold ) ? GESTURES_MOTION_DOWN_STATE : GESTURES_MOTION_UP_STATE;
+	}
+	else
+	{
+		return_code = ( belowThreshold ) ? GESTURES_MOTION_DROP_DOWN : GESTURES_MOTION_RAISE_UP;
+		data->timestamp = timestamp;
+	}
+	return return_code;
+}

--- a/src/tof_motion.h
+++ b/src/tof_motion.h
@@ -1,0 +1,95 @@
+/*******************************************************************************
+Copyright © 2015, STMicroelectronics International N.V.
+All rights reserved.
+
+Use and Redistribution are permitted only in accordance with licensing terms 
+available at www.st.com under software reference X-CUBE-6180XA1, and provided
+that the following conditions are met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+* Neither the name of STMicroelectronics nor the
+names of its contributors may be used to endorse or promote products
+derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROTECTED BY STMICROELECTRONICS PATENTS AND COPYRIGHTS.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND
+NON-INFRINGEMENT OF INTELLECTUAL PROPERTY RIGHTS ARE DISCLAIMED.
+IN NO EVENT SHALL STMICROELECTRONICS INTERNATIONAL N.V. BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+********************************************************************************/
+
+/*
+ * @file tof_motion.h
+ * $Date: 2015-11-10 11:21:53 +0100 (Tue, 10 Nov 2015) $
+ * $Revision: 2612 $
+ */
+
+#ifndef TOF_MOTION_H_
+#define TOF_MOTION_H_
+
+#include "tof_gestures_platform.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @defgroup tof_motion Motion
+ *  @brief    Motion detector based on simple threshold
+    @par Description
+    This module returns one of the states defined in ::Gestures_Motion_Code_t based on a programmable range threshold.
+    When a transition state is returned (::GESTURES_MOTION_RAISE_UP or ::GESTURES_MOTION_DROP_DOWN), it also returns the
+    duration (in ms) of the previous state. For instance, assuming ::GESTURES_MOTION_RAISE_UP is returned, duration is
+    the time the state ::GESTURES_MOTION_DOWN_STATE has been maintained before the down=>up transition.   
+ *  @ingroup tof
+ *  @{  
+ */
+    
+/** Codes associated to Motion detection
+ */
+enum Gestures_Motion_Code_t{
+    GESTURES_MOTION_NULL        = 0, /*!< No motion detected */
+    GESTURES_MOTION_DOWN_STATE  = 1, /*!< Hand is down (below threshold) */
+    GESTURES_MOTION_UP_STATE    = 2, /*!< Hand is up (above threshold) */
+    GESTURES_MOTION_RAISE_UP     = 3, /*!< Hand is raising up (transition from DOWN_STATE to UP_STATE is detected) */
+    GESTURES_MOTION_DROP_DOWN    = 4, /*!< Hand is dropping down (transition from UP_STATE to DOWN_STATE is detected) */
+};
+
+/**
+ * @struct MotionData_t
+ * @brief Data structure for motion detection
+ */ 
+typedef struct {
+    int threshold;               /*!< Input : Range threshold */
+    long duration;               /*!< Output : Duration (in ms) */
+    int previousRange;           /*!< Private : Obvious */
+    unsigned long timestamp;     /*!< Private : Obvious */
+    bool firstTime;              /*!< Private : True only the first time */   
+} MotionData_t;
+
+/**
+ * @brief Initialize Motion data
+ * @return 0 on success
+ */
+int tof_initMotion(int threshold, MotionData_t *data);
+/**
+ * @brief Return current motion state
+   @return One of the states defined in ::Gestures_Motion_Code_t 
+ */
+int tof_getMotion(int32_t range_mm, MotionData_t *data);
+
+ /** @}  */
+    
+#ifdef __cplusplus
+}					
+#endif	
+#endif /* TOF_MOTION_H_ */


### PR DESCRIPTION
Move the code for proximity gesture detection in a dedicated library so it can be used as for VL53L0X as for VL6180X. 